### PR TITLE
Last non direct

### DIFF
--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -83,10 +83,10 @@ remove_dupes as
 join_traffic_source as (
     select 
         remove_dupes.*,
-        source as source,
-        medium as medium,
-        campaign as campaign,
-        default_channel_grouping as default_channel_grouping,
+        last_non_direct_source as source,
+        last_non_direct_medium as medium,
+        last_non_direct_campaign as campaign,
+        last_non_direct_default_channel_grouping as default_channel_grouping,
         session_default_channel_grouping as session_default_channel_grouping,
         mv_author_session_status
     from remove_dupes

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -83,7 +83,8 @@ join_traffic_source as (
         session_source as source,
         session_medium as medium,
         session_campaign as campaign,
-        session_default_channel_grouping as default_channel_grouping
+        default_channel_grouping as default_channel_grouping,
+        session_default_channel_grouping as session_default_channel_grouping
     from remove_dupes
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)
 )

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -86,8 +86,8 @@ join_traffic_source as (
         last_non_direct_source as source,
         last_non_direct_medium as medium,
         last_non_direct_campaign as campaign,
-        last_non_direct_default_channel_grouping as default_channel_grouping,
-        session_default_channel_grouping as session_default_channel_grouping,
+        last_non_direct_default_channel_grouping as last_non_direct_channel,
+        session_default_channel_grouping as default_channel_grouping,
         mv_author_session_status
     from remove_dupes
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -33,6 +33,7 @@
 with session_start_dims as (
     select 
         session_key,
+        user_key,
         ga_session_number,
         event_date_dt as session_start_date,
         page_location as landing_page,
@@ -82,13 +83,13 @@ remove_dupes as
 join_traffic_source as (
     select 
         remove_dupes.*,
-        source,
-        medium,
-        source_category,
-        campaign,
-        content,
-        term,
-        default_channel_grouping,
+        session_source,
+        session_medium,
+        session_source_category,
+        session_campaign,
+        session_content,
+        session_term,
+        session_channel,
         last_non_direct_source,
         last_non_direct_medium,
         last_non_direct_source_category,

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -8,6 +8,7 @@
         config(
             materialized = 'incremental',
             incremental_strategy = 'insert_overwrite',
+            schema = 'analytics',
             partition_by={
                 "field": "session_start_date",
                 "data_type": "date",
@@ -20,6 +21,7 @@
         config(
             materialized = 'incremental',
             incremental_strategy = 'insert_overwrite',
+            schema = 'analytics',
             partition_by={
                 "field": "session_start_date",
                 "data_type": "date",
@@ -35,6 +37,7 @@ with session_start_dims as (
         event_date_dt as session_start_date,
         page_location as landing_page,
         page_hostname as landing_page_hostname,
+        mv_region,
         geo_continent,
         geo_country,
         geo_region,
@@ -80,11 +83,12 @@ remove_dupes as
 join_traffic_source as (
     select 
         remove_dupes.*,
-        session_source as source,
-        session_medium as medium,
-        session_campaign as campaign,
+        source as source,
+        medium as medium,
+        campaign as campaign,
         default_channel_grouping as default_channel_grouping,
-        session_default_channel_grouping as session_default_channel_grouping
+        session_default_channel_grouping as session_default_channel_grouping,
+        mv_author_session_status
     from remove_dupes
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)
 )

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -74,7 +74,6 @@ with session_start_dims as (
         {% endif %}
     {% endif %}
 ),
--- Arbitrarily pull the first session_start event to remove duplicates
 remove_dupes as 
 (
     select * from session_start_dims
@@ -85,6 +84,7 @@ join_traffic_source as (
         *
     from remove_dupes
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)
+    left join {{ ref ('stg_ga4__last_non_direct_attribution')}} using (session_key)
 )
 
 select * from join_traffic_source

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -81,7 +81,21 @@ remove_dupes as
 ),
 join_traffic_source as (
     select 
-        *
+        remove_dupes.*,
+        source,
+        medium,
+        source_category,
+        campaign,
+        content,
+        term,
+        default_channel_grouping,
+        last_non_direct_source,
+        last_non_direct_medium,
+        last_non_direct_source_category,
+        last_non_direct_campaign,
+        last_non_direct_content,
+        last_non_direct_term,
+        last_non_direct_channel
     from remove_dupes
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)
     left join {{ ref ('stg_ga4__last_non_direct_attribution')}} using (session_key)

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -82,13 +82,7 @@ remove_dupes as
 ),
 join_traffic_source as (
     select 
-        remove_dupes.*,
-        last_non_direct_source as source,
-        last_non_direct_medium as medium,
-        last_non_direct_campaign as campaign,
-        last_non_direct_default_channel_grouping as last_non_direct_channel,
-        session_default_channel_grouping as default_channel_grouping,
-        mv_author_session_status
+        *
     from remove_dupes
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)
 )

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -132,6 +132,8 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'source') }},
         {{ ga4.unnest_key('event_params', 'medium') }},
         {{ ga4.unnest_key('event_params', 'campaign') }},
+        {{ ga4.unnest_key('event_params', 'content') }},
+        {{ ga4.unnest_key('event_params', 'term') }},
         {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
         CASE 
             WHEN event_name = 'page_view' THEN 1

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -99,6 +99,8 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'source') }},
         {{ ga4.unnest_key('event_params', 'medium') }},
         {{ ga4.unnest_key('event_params', 'campaign') }},
+        {{ ga4.unnest_key('event_params', 'content') }},
+        {{ ga4.unnest_key('event_params', 'term') }},
         {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
         CASE 
             WHEN event_name = 'page_view' THEN 1

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -33,12 +33,15 @@ last_pageview_joined as (
 ),
 session_params as (
   select
-    last_pageview_joined.*,
+    last_pageview_joined.* except(source,medium, campaign),
     last_non_direct_source,
     last_non_direct_medium,
     last_non_direct_campaign,
-    last_non_direct_default_channel_grouping,
-    session_default_channel_grouping,
+    last_non_direct_channel,
+    source,
+    medium,
+    campaign,
+    default_channel_grouping,
     mv_author_session_status
   from {{ref('stg_ga4__sessions_traffic_sources')}}
   right join last_pageview_joined using(session_key)

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -17,7 +17,7 @@
 ),
 last_pageview_joined as (
   select 
-    page_view_with_params.* except(load_time),
+    page_view_with_params.* except(load_time, source,medium, campaign),
     case
         when load_time < 0 then null
         when load_time > 100000 then null
@@ -33,7 +33,7 @@ last_pageview_joined as (
 ),
 session_params as (
   select
-    last_pageview_joined.* except(source,medium, campaign),
+    last_pageview_joined.* ,
     source,
     medium,
     campaign,

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -45,7 +45,7 @@ session_params as (
 last_non_direct as (
   select 
     *
-  from {{ref('stt_ga4__last_non_direct_attribution')}}
+  from {{ref('stg_ga4__last_non_direct_attribution')}}
   right join session_params using(session_key)
 )
 

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -34,10 +34,10 @@ last_pageview_joined as (
 session_params as (
   select
     last_pageview_joined.*,
-    source,
-    medium,
-    campaign,
-    default_channel_grouping,
+    last_non_direct_source,
+    last_non_direct_medium,
+    last_non_direct_campaign,
+    last_non_direct_default_channel_grouping,
     session_default_channel_grouping,
     mv_author_session_status
   from {{ref('stg_ga4__sessions_traffic_sources')}}

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -34,10 +34,6 @@ last_pageview_joined as (
 session_params as (
   select
     last_pageview_joined.* except(source,medium, campaign),
-    last_non_direct_source,
-    last_non_direct_medium,
-    last_non_direct_campaign,
-    last_non_direct_channel,
     source,
     medium,
     campaign,
@@ -45,6 +41,12 @@ session_params as (
     mv_author_session_status
   from {{ref('stg_ga4__sessions_traffic_sources')}}
   right join last_pageview_joined using(session_key)
+),
+last_non_direct as (
+  select 
+    *
+  from {{ref('stt_ga4__last_non_direct_attribution')}}
+  right join session_params using(session_key)
 )
 
 select * from session_params

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -17,7 +17,12 @@
 ),
 last_pageview_joined as (
   select 
-    page_view_with_params.*,
+    page_view_with_params.* except(load_time),
+    case
+        when load_time < 0 then null
+        when load_time > 100000 then null
+        else load_time
+    end as load_time,
     case
       when first_last_pageview_session.last_page_view_event_key is null then null
       else 1
@@ -25,6 +30,18 @@ last_pageview_joined as (
   from page_view_with_params
     left join {{ref('stg_ga4__sessions_first_last_pageviews')}} first_last_pageview_session
       on page_view_with_params.event_key = first_last_pageview_session.last_page_view_event_key
+),
+session_params as (
+  select
+    last_pageview_joined.*,
+    source,
+    medium,
+    campaign,
+    default_channel_grouping,
+    session_default_channel_grouping,
+    mv_author_session_status
+  from {{ref('stg_ga4__sessions_traffic_sources')}}
+  right join last_pageview_joined using(session_key)
 )
 
-select * from last_pageview_joined
+select * from session_params

--- a/models/staging/ga4/stg_ga4__attribution_window.sql
+++ b/models/staging/ga4/stg_ga4__attribution_window.sql
@@ -1,9 +1,6 @@
 -- This staging model contains key creation and window functions. Keeping window functions outside of the base incremental model ensures that the incremental updates don't artificially limit the window partition sizes (ex: if a session spans 2 days, but only 1 day is in the incremental update)
 {% if not flags.FULL_REFRESH %}
-    {% set partitions_to_query = ['current_date'] %}
-    {% for i in range(var('attribution_window', 30)) %}
-        {% set partitions_to_query = partitions_to_query.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
-    {% endfor %}
+    {% set min_partition_to_query = 'date_sub(current_date, interval '+ (var("attribution_window", 30) + var("static_incremental_days")  ) +' day )' %}
 {% endif %}
 with base_events as (
     select
@@ -19,13 +16,24 @@ with base_events as (
         stream_id,
         ga_session_id
     from {{ ref('base_ga4__events')}}
-    where (source is not null and medium is not null and campaign is not null)
     {% if not flags.FULL_REFRESH %}
-        and event_date_dt in ({{ partitions_to_query | join(',') }})
+        and event_date_dt >= ({{ min_partition_to_query }})
     {% endif %}
     {% if var('frequency', 'daily') == 'daily+streaming' %}
     union all
-    select * from {{ref('base_ga4__events_intraday')}}
+    select
+        user_pseudo_id,
+        event_date_dt,
+        event_timestamp,
+        campaign,
+        source,
+        medium,
+        content,
+        term,
+        event_name,
+        stream_id,
+        ga_session_id
+    from {{ref('base_ga4__events_intraday')}}
     {% endif %}
 ),
 -- Add a unique key for the user that checks for user_id and then pseudo_user_id

--- a/models/staging/ga4/stg_ga4__attribution_window.sql
+++ b/models/staging/ga4/stg_ga4__attribution_window.sql
@@ -18,7 +18,11 @@ with base_events as (
         event_name,
         stream_id,
         ga_session_id
+    {% if var('frequency', 'daily') == 'streaming' %}
+    from {{ ref('base_ga4__events_intraday')}}
+    {% else %}
     from {{ ref('base_ga4__events')}}
+    {% endif %}
     {% if not flags.FULL_REFRESH %}
         where event_date_dt in ({{ partitions_to_query | join(',') }})
     {% endif %}

--- a/models/staging/ga4/stg_ga4__attribution_window.sql
+++ b/models/staging/ga4/stg_ga4__attribution_window.sql
@@ -1,0 +1,41 @@
+-- This staging model contains key creation and window functions. Keeping window functions outside of the base incremental model ensures that the incremental updates don't artificially limit the window partition sizes (ex: if a session spans 2 days, but only 1 day is in the incremental update)
+{% if not flags.FULL_REFRESH %}
+    {% set partitions_to_query = ['current_date'] %}
+    {% for i in range(var('attribution_window', 30)) %}
+        {% set partitions_to_query = partitions_to_query.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+    {% endfor %}
+{% endif %}
+with base_events as (
+    select
+        user_pseudo_id,
+        event_date_dt,
+        event_timestamp,
+        campaign,
+        source,
+        medium
+    from {{ ref('base_ga4__events')}}
+    {% if not flags.FULL_REFRESH %}
+        where event_date_dt in ({{ partitions_to_query | join(',') }})
+    {% endif %}
+    {% if var('frequency', 'daily') == 'daily+streaming' %}
+    union all
+    select * from {{ref('base_ga4__events_intraday')}}
+    {% endif %}
+),
+-- Add a unique key for the user that checks for user_id and then pseudo_user_id
+add_user_key as (
+    select 
+        *,
+        to_base64(md5(user_pseudo_id)) as user_key
+        -- in this implementation, sessions break when a user id is added or removed during a session
+        -- there is a fix in the main package, but implementing it here is a major task
+        --case
+        --    when user_id is not null then to_base64(md5(user_id))
+        --    when user_pseudo_id is not null then to_base64(md5(user_pseudo_id))
+        --    else null -- this case is reached when privacy settings are enabled
+        --end as user_key
+    from base_events
+)
+
+
+select * from add_user_key

--- a/models/staging/ga4/stg_ga4__attribution_window.sql
+++ b/models/staging/ga4/stg_ga4__attribution_window.sql
@@ -1,8 +1,5 @@
 -- This staging model contains key creation and window functions. Keeping window functions outside of the base incremental model ensures that the incremental updates don't artificially limit the window partition sizes (ex: if a session spans 2 days, but only 1 day is in the incremental update)
 {% if not flags.FULL_REFRESH %}
-    {% set min_partition_to_query = 'date_sub(current_date, interval '+ (var("attribution_window", 30) + var("static_incremental_days", 1)  ) +' day )' %}
-{% endif %}
-{% if not flags.FULL_REFRESH %}
     {% set partitions_to_query = ['current_date'] %}
     {% for i in range(var("attribution_window", 30) + var("static_incremental_days", 1)) %}
         {% set partitions_to_query = partitions_to_query.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}

--- a/models/staging/ga4/stg_ga4__attribution_window.sql
+++ b/models/staging/ga4/stg_ga4__attribution_window.sql
@@ -18,11 +18,7 @@ with base_events as (
         event_name,
         stream_id,
         ga_session_id
-    {% if var('frequency', 'daily') == 'streaming' %}
-    from {{ ref('base_ga4__events_intraday')}}
-    {% else %}
     from {{ ref('base_ga4__events')}}
-    {% endif %}
     {% if not flags.FULL_REFRESH %}
         where event_date_dt in ({{ partitions_to_query | join(',') }})
     {% endif %}

--- a/models/staging/ga4/stg_ga4__attribution_window.sql
+++ b/models/staging/ga4/stg_ga4__attribution_window.sql
@@ -13,6 +13,8 @@ with base_events as (
         campaign,
         source,
         medium,
+        content,
+        term,
         event_name,
         stream_id,
         ga_session_id

--- a/models/staging/ga4/stg_ga4__last_non_direct_attribution.sql
+++ b/models/staging/ga4/stg_ga4__last_non_direct_attribution.sql
@@ -1,14 +1,14 @@
-last_non_direct as (
+with last_non_direct as (
     select distinct
         session_key,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source END)) OVER (session_window), '(direct)') AS last_non_direct_source,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then medium END)) OVER (session_window), '(none)') AS last_non_direct_medium,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source_category END)) OVER (session_window), '(none)') AS last_non_direct_source_category,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then campaign END)) OVER (session_window), '(none)') AS last_non_direct_campaign,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then content END)) OVER (session_window), '(none)') AS last_non_direct_content,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then term END)) OVER (session_window), '(none)') AS last_non_direct_term,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then default_channel_grouping END)) OVER (session_window), 'Direct') AS last_non_direct_channel,
+        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source END)) OVER (user_window), '(direct)') AS last_non_direct_source,
+        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then medium END)) OVER (user_window), '(none)') AS last_non_direct_medium,
+        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source_category END)) OVER (user_window), '(none)') AS last_non_direct_source_category,
+        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then campaign END)) OVER (user_window), '(none)') AS last_non_direct_campaign,
+        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then content END)) OVER (user_window), '(none)') AS last_non_direct_content,
+        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then term END)) OVER (user_window), '(none)') AS last_non_direct_term,
+        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then default_channel_grouping END)) OVER (user_window), 'Direct') AS last_non_direct_channel,
     from {{ ref('stg_ga4__sessions_traffic_sources') }}
-    WINDOW session_window AS (PARTITION BY user_key ORDER BY unix_seconds(timestamp_seconds(event_timestamp)) range between ({{var('attribution_window',30) * 24 * 60 * 60}}  )  preceding and current row)
+    WINDOW user_window AS (PARTITION BY user_key ORDER BY event_timestamp  range between ({{var('attribution_window',30) * 24 * 60 * 60}}  )  preceding and current row)
 )
 select * from last_non_direct

--- a/models/staging/ga4/stg_ga4__last_non_direct_attribution.sql
+++ b/models/staging/ga4/stg_ga4__last_non_direct_attribution.sql
@@ -1,14 +1,14 @@
 with last_non_direct as (
     select distinct
-        session_key,
-        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source END)) OVER (user_window), '(direct)') AS last_non_direct_source,
-        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then medium END)) OVER (user_window), '(none)') AS last_non_direct_medium,
-        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source_category END)) OVER (user_window), '(none)') AS last_non_direct_source_category,
-        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then campaign END)) OVER (user_window), '(none)') AS last_non_direct_campaign,
-        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then content END)) OVER (user_window), '(none)') AS last_non_direct_content,
-        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then term END)) OVER (user_window), '(none)') AS last_non_direct_term,
-        COALESCE(LAST_VALUE((CASE WHEN source <> '(direct)' and source is not null then default_channel_grouping END)) OVER (user_window), 'Direct') AS last_non_direct_channel,
+        first_value(session_key) over (user_window) as session_key,
+        COALESCE(first_value((CASE WHEN session_source <> '(direct)' then session_source else null END) ignore nulls) OVER (user_window), '(direct)') AS last_non_direct_source,
+        COALESCE(first_value((CASE WHEN session_source <> '(direct)' then session_medium else null END) ignore nulls) OVER (user_window), '(none)') AS last_non_direct_medium,
+        COALESCE(first_value((CASE WHEN session_source <> '(direct)' then session_source_category else null END) ignore nulls) OVER (user_window), '(none)') AS last_non_direct_source_category,
+        COALESCE(first_value((CASE WHEN session_source <> '(direct)' then session_campaign else null END) ignore nulls) OVER (user_window), '(none)') AS last_non_direct_campaign,
+        COALESCE(first_value((CASE WHEN session_source <> '(direct)' then session_content else null END) ignore nulls) OVER (user_window), '(none)') AS last_non_direct_content,
+        COALESCE(first_value((CASE WHEN session_source <> '(direct)' then session_term else null END) ignore nulls) OVER (user_window), '(none)') AS last_non_direct_term,
+        COALESCE(first_value((CASE WHEN session_source <> '(direct)' then session_channel else null END) ignore nulls) OVER (user_window), 'Direct') AS last_non_direct_channel,
     from {{ ref('stg_ga4__sessions_traffic_sources') }}
-    WINDOW user_window AS (PARTITION BY user_key ORDER BY event_timestamp  range between ({{var('attribution_window',30) * 24 * 60 * 60}}  )  preceding and current row)
+    WINDOW user_window AS (PARTITION BY user_key ORDER BY session_start_timestamp desc  range between ({{var('attribution_window',30) * 24 * 60 * 60}}  )  preceding and current row)
 )
 select * from last_non_direct

--- a/models/staging/ga4/stg_ga4__last_non_direct_attribution.sql
+++ b/models/staging/ga4/stg_ga4__last_non_direct_attribution.sql
@@ -1,0 +1,14 @@
+last_non_direct as (
+    select distinct
+        session_key,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source END)) OVER (session_window), '(direct)') AS last_non_direct_source,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then medium END)) OVER (session_window), '(none)') AS last_non_direct_medium,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source_category END)) OVER (session_window), '(none)') AS last_non_direct_source_category,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then campaign END)) OVER (session_window), '(none)') AS last_non_direct_campaign,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then content END)) OVER (session_window), '(none)') AS last_non_direct_content,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then term END)) OVER (session_window), '(none)') AS last_non_direct_term,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then default_channel_grouping END)) OVER (session_window), 'Direct') AS last_non_direct_channel,
+    from {{ ref('stg_ga4__sessions_traffic_sources') }}
+    WINDOW session_window AS (PARTITION BY user_key ORDER BY unix_seconds(timestamp_seconds(event_timestamp)) range between ({{var('attribution_window',30) * 24 * 60 * 60}}  )  preceding and current row)
+)
+select * from last_non_direct

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -25,13 +25,13 @@ last_non_direct_source as (
     select    
         session_key,
         event_timestamp,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS source,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS medium,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS source_category,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS campaign,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS content,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS term,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS default_channel_grouping
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS last_non_direct_source,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_medium,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_source_category,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_campaign,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_content,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_term,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_default_channel_grouping
     from set_default_channel_grouping
     WINDOW session_window AS (PARTITION BY user_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 ),

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -24,6 +24,7 @@ set_default_channel_grouping as (
 last_non_direct_source as (
     select    
         session_key,
+        event_timestamp,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS source,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS medium,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS source_category,
@@ -39,7 +40,7 @@ session_source as (
         *,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS default_channel_grouping
     from last_non_direct_source
-    WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+    WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 
 ),
 mv_custom as (

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -32,7 +32,7 @@ session_source as (
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_campaign,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_content,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_term,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, 'Direct') END) IGNORE NULLS) OVER (session_window), 'Direct') AS session_channel_grouping,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, 'Direct') END) IGNORE NULLS) OVER (session_window), 'Direct') AS session_channel,
         FIRST_VALUE(event_timestamp IGNORE NULLS) OVER (session_window) AS session_start_timestamp,
     from set_default_channel_grouping
     WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
@@ -41,7 +41,7 @@ mv_custom as (
   select
         *,
         case
-            when default_channel_grouping in ('Affiliates','Paid Search', 'Paid Video', 'Display', 'Cross-network', 'Paid Social', 'Paid Other', 'Paid Shopping', 'Audio','Email','Mobile Push Notifications', 'Other', 'SMS') then 'Paid'
+            when session_channel in ('Affiliates','Paid Search', 'Paid Video', 'Display', 'Cross-network', 'Paid Social', 'Paid Other', 'Paid Shopping', 'Audio','Email','Mobile Push Notifications', 'Other', 'SMS') then 'Paid'
             else 'Organic'
         end as mv_author_session_status,
   from session_source

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -6,7 +6,7 @@ with session_events as (
         medium,
         campaign,
         source_category
-    from {{ref('stg_ga4__events')}}
+    from {{ref('stg_ga4__attribution_window')}}
     left join {{ref('ga4_source_categories')}} using (source)
     --exclude the events session_start and first_visit because they are triggered first but never contain source, medium, campaign values
     where not ( event_name = "session_start" or event_name = "first_visit")
@@ -19,26 +19,13 @@ set_default_channel_grouping as (
     from session_events
 ),
 session_source as (
-    select    
-        session_key,
-
-        (case
-          when FIRST_VALUE(source) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) is null then "(direct)"
-          else FIRST_VALUE(source) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) end
-        ) as session_source,
-
-        (case 
-          when FIRST_VALUE(medium) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) is null then "(none)"
-          else FIRST_VALUE(medium) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) end
-        ) as session_medium,
-
-        (case 
-          when FIRST_VALUE(campaign) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) is null then "(direct)"
-          else FIRST_VALUE(campaign) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) end
-        ) as session_campaign,
-
-        FIRST_VALUE(default_channel_grouping) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS session_default_channel_grouping
-    from set_default_channel_grouping
+  select    
+    session_key,
+    ifnull( first_value( source ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(direct)') as last_non_null_source,
+    ifnull( first_value( medium ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(none)') as last_non_null_medium
+    ifnull( first_value( campaign ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(direct)') as last_non_null_campaign
+    ifnull( first_value( nullif(default_channel_grouping, 'Direct' ) ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), 'Direct') as last_non_direct_channel_grouping
+  from set_default_channel_grouping
 )
 
 select distinct  * from session_source

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -21,19 +21,6 @@ set_default_channel_grouping as (
         {{ga4.default_channel_grouping('source','medium','source_category')}} as default_channel_grouping
     from session_events
 ),
-last_non_direct as (
-    select distinct
-        session_key,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source END)) OVER (session_window), '(direct)') AS last_non_direct_source,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then medium END)) OVER (session_window), '(none)') AS last_non_direct_medium,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source_category END)) OVER (session_window), '(none)') AS last_non_direct_source_category,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then campaign END)) OVER (session_window), '(none)') AS last_non_direct_campaign,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then content END)) OVER (session_window), '(none)') AS last_non_direct_content,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then term END)) OVER (session_window), '(none)') AS last_non_direct_term,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then default_channel_grouping END)) OVER (session_window), 'Direct') AS last_non_direct_channel,
-    from set_default_channel_grouping
-    WINDOW session_window AS (PARTITION BY user_key ORDER BY unix_micros(timestamp_micros(event_timestamp)) range between ({{var('attribution_window',30) * 24 * 60 * 60}}  )  preceding and current row)
-),
 session_source as (
     select distinct
         session_key,
@@ -56,7 +43,6 @@ mv_custom as (
             else 'Organic'
         end as mv_author_session_status,
   from session_source
-  left join last_non_direct using (session_key)
 )
 
 select * from mv_custom

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -41,7 +41,7 @@ session_source as (
     from last_non_direct_source
     WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 
-)
+),
 mv_custom as (
   select
         *,

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -6,6 +6,8 @@ with session_events as (
         lower(source) as source,
         medium,
         campaign,
+        content,
+        term,
         source_category
     from {{ref('stg_ga4__attribution_window')}}
     left join {{ref('ga4_source_categories')}} using (source)

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -26,14 +26,14 @@ session_source as (
         session_key,
         user_key,
         -- if a user_id is added mid-session, the source gets populated as direct so we ignore direct and null source but defaults to direct/none
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS source, 
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS medium,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS source_category,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS campaign,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS content,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS term,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, 'Direct') END) IGNORE NULLS) OVER (session_window), 'Direct') AS default_channel_grouping,
-        FIRST_VALUE((CASE WHEN source <> '(direct)' THEN event_timestamp END) IGNORE NULLS) OVER (session_window) AS event_timestamp,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS session_source, 
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_medium,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_source_category,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_campaign,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_content,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_term,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, 'Direct') END) IGNORE NULLS) OVER (session_window), 'Direct') AS session_channel_grouping,
+        FIRST_VALUE(event_timestamp IGNORE NULLS) OVER (session_window) AS session_start_timestamp,
     from set_default_channel_grouping
     WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 ),

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -24,6 +24,7 @@ set_default_channel_grouping as (
 session_source as (
     select distinct
         session_key,
+        user_key,
         -- if a user_id is added mid-session, the source gets populated as direct so we ignore direct and null source but defaults to direct/none
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS source, 
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS medium,
@@ -31,7 +32,8 @@ session_source as (
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS campaign,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS content,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS term,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, 'Direct') END) IGNORE NULLS) OVER (session_window), 'Direct') AS default_channel_grouping
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, 'Direct') END) IGNORE NULLS) OVER (session_window), 'Direct') AS default_channel_grouping,
+        FIRST_VALUE((CASE WHEN source <> '(direct)' THEN event_timestamp END) IGNORE NULLS) OVER (session_window) AS event_timestamp,
     from set_default_channel_grouping
     WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 ),

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -25,20 +25,22 @@ last_non_direct_source as (
     select    
         session_key,
         event_timestamp,
+        source,
+        default_channel_grouping,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS last_non_direct_source,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_medium,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_source_category,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_campaign,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_content,
         COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_term,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_default_channel_grouping
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), 'Direct') AS last_non_direct_default_channel_grouping
     from set_default_channel_grouping
     WINDOW session_window AS (PARTITION BY user_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 ),
 session_source as (
     select
         *,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_default_channel_grouping
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), 'Direct') AS session_default_channel_grouping
     from last_non_direct_source
     WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -21,38 +21,42 @@ set_default_channel_grouping as (
         {{ga4.default_channel_grouping('source','medium','source_category')}} as default_channel_grouping
     from session_events
 ),
-last_non_direct_source as (
-    select    
+last_non_direct as (
+    select distinct
         session_key,
-        event_timestamp,
-        source,
-        default_channel_grouping,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS last_non_direct_source,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_medium,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_source_category,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_campaign,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_content,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS last_non_direct_term,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), 'Direct') AS last_non_direct_default_channel_grouping
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source END)) OVER (session_window), '(direct)') AS last_non_direct_source,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then medium END)) OVER (session_window), '(none)') AS last_non_direct_medium,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then source_category END)) OVER (session_window), '(none)') AS last_non_direct_source_category,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then campaign END)) OVER (session_window), '(none)') AS last_non_direct_campaign,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then content END)) OVER (session_window), '(none)') AS last_non_direct_content,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then term END)) OVER (session_window), '(none)') AS last_non_direct_term,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' and source is not null then default_channel_grouping END)) OVER (session_window), 'Direct') AS last_non_direct_channel,
     from set_default_channel_grouping
-    WINDOW session_window AS (PARTITION BY user_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+    WINDOW session_window AS (PARTITION BY user_key ORDER BY unix_micros(timestamp_micros(event_timestamp)) range between ({{var('attribution_window',30) * 24 * 60 * 60}}  )  preceding and current row)
 ),
 session_source as (
-    select
-        *,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), 'Direct') AS session_default_channel_grouping
-    from last_non_direct_source
+    select distinct
+        session_key,
+        -- if a user_id is added mid-session, the source gets populated as direct so we ignore direct and null source but defaults to direct/none
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN source END) IGNORE NULLS) OVER (session_window), '(direct)') AS source, 
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS medium,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS source_category,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS campaign,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS content,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS term,
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, 'Direct') END) IGNORE NULLS) OVER (session_window), 'Direct') AS default_channel_grouping
+    from set_default_channel_grouping
     WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
-
 ),
 mv_custom as (
   select
         *,
         case
-            when session_default_channel_grouping in ('Affiliates','Paid Search', 'Paid Video', 'Display', 'Cross-network', 'Paid Social', 'Paid Other', 'Paid Shopping', 'Audio','Email','Mobile Push Notifications', 'Other', 'SMS') then 'Paid'
+            when default_channel_grouping in ('Affiliates','Paid Search', 'Paid Video', 'Display', 'Cross-network', 'Paid Social', 'Paid Other', 'Paid Shopping', 'Audio','Email','Mobile Push Notifications', 'Other', 'SMS') then 'Paid'
             else 'Organic'
         end as mv_author_session_status,
   from session_source
+  left join last_non_direct using (session_key)
 )
 
-select distinct  * from mv_custom
+select * from mv_custom

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -38,7 +38,7 @@ last_non_direct_source as (
 session_source as (
     select
         *,
-        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS default_channel_grouping
+        COALESCE(FIRST_VALUE((CASE WHEN source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_default_channel_grouping
     from last_non_direct_source
     WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -21,10 +21,10 @@ set_default_channel_grouping as (
 session_source as (
   select    
     session_key,
-    ifnull( first_value( source ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(direct)') as last_non_null_source,
-    ifnull( first_value( medium ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(none)') as last_non_null_medium
-    ifnull( first_value( campaign ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(direct)') as last_non_null_campaign
-    ifnull( first_value( nullif(default_channel_grouping, 'Direct' ) ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), 'Direct') as last_non_direct_channel_grouping
+    ifnull( first_value( source ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(direct)') as session_source,
+    ifnull( first_value( medium ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(none)') as session_medium,
+    ifnull( first_value( campaign ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), '(direct)') as session_campaign,
+    ifnull( first_value( nullif(default_channel_grouping, 'Direct' ) ignore nulls ) over (partition by user_key order by unix_micros(timestamp_micros(event_timestamp)) range between 30 preceding and current row), 'Direct') as default_channel_grouping
   from set_default_channel_grouping
 )
 

--- a/models/staging/ga4/stg_ga4__users_last_events.sql
+++ b/models/staging/ga4/stg_ga4__users_last_events.sql
@@ -35,4 +35,4 @@ events_joined as (
     from {{ref('stg_ga4__users_last_pageviews')}}
     right join events_joined using (user_key)
 )
-select * from pageview
+select distinct * from pageview

--- a/models/staging/ga4/stg_ga4__users_last_pageviews.sql
+++ b/models/staging/ga4/stg_ga4__users_last_pageviews.sql
@@ -23,4 +23,4 @@ page_views_joined as (
         on page_views_by_user_key.last_page_view_event_key = last_page_view.event_key
 )
 
-select * from page_views_joined
+select distinct * from page_views_joined


### PR DESCRIPTION
## Description & motivation
Last, non-direct attribution is the default reporting mode in UA and GA4. This PR brings last, non-direct attribution to the dbt-GA4 package adding last_non_direct_* (source, medium, campaign, term, content., channel) to the session models.

