### PR TITLE
page_view and author marts

### DIFF
--- a/models/marts/core/dim_ga4__authors.sql
+++ b/models/marts/core/dim_ga4__authors.sql
@@ -1,0 +1,48 @@
+{% if is_incremental %}
+    {% set partitions_to_replace = ['current_date'] %}
+    {% for i in range(var('static_incremental_days', 1)) %}
+        {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+    {% endfor %}
+    {{
+        config(
+            materialized = 'incremental',
+            incremental_strategy = 'insert_overwrite',
+            schema = 'analytics',
+            partition_by={
+                "field": "event_date_dt",
+                "data_type": "date",
+            },
+            partitions = partitions_to_replace,
+        )
+    }}
+{% else %}
+    {{
+        config(
+            materialized = 'incremental',
+            incremental_strategy = 'insert_overwrite',
+            schema = 'analytics',
+            partition_by={
+                "field": "event_date_dt",
+                "data_type": "date",
+            },
+        )
+    }}
+{% endif %}
+with authors as (
+    select
+        author,
+        event_date_dt,
+        concat(cast(extract(year from event_date_dt) as string),'-',  cast(extract(month from event_date_dt) as string)) as year_month,
+        count(distinct case when date_trunc(event_date_dt, month) = date_trunc(article_pubdate, month) then page_location else null end) as articles_published_in_year_month,
+        count (geo_country) as page_views,
+        countif (geo_country = 'United States' and mv_author_session_status = 'author_payable') as us_organic_page_views,
+        countif (geo_country = 'United States' and mv_author_session_status = 'author_non_payable') as us_paid_page_views,
+        countif (geo_country != 'United States' and mv_author_session_status = 'author_payable') as global_organic_page_views,
+        countif (geo_country != 'United States' and mv_author_session_status = 'author_non_payable') as global_paid_page_views,
+    from {{ref('fct_ga4__event_page_view')}}
+    {% if is_incremental() and var('static_incremental_days', 1) %}
+        where event_date_dt in ({{ partitions_to_replace | join(',') }})
+    {% endif %}
+    group by 1,2,3
+)
+select * from authors

--- a/models/marts/core/fct_ga4__event_page_view.sql
+++ b/models/marts/core/fct_ga4__event_page_view.sql
@@ -1,0 +1,67 @@
+{% if is_incremental %}
+    {% set partitions_to_replace = ['current_date'] %}
+    {% for i in range(var('static_incremental_days', 1)) %}
+        {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+    {% endfor %}
+    {{
+        config(
+            materialized = 'incremental',
+            incremental_strategy = 'insert_overwrite',
+            schema = 'analytics',
+            partition_by={
+                "field": "event_date_dt",
+                "data_type": "date",
+            },
+            partitions = partitions_to_replace,
+        )
+    }}
+{% else %}
+    {{
+        config(
+            materialized = 'incremental',
+            incremental_strategy = 'insert_overwrite',
+            schema = 'analytics',
+            partition_by={
+                "field": "event_date_dt",
+                "data_type": "date",
+            },
+        )
+    }}
+{% endif %}
+select
+    event_key,
+    user_key,
+    session_key,
+    page_key,
+    article_id,
+    event_date_dt,
+    event_timestamp,
+    event_name,
+    case 
+        when geo_country = 'United States' then 'US'
+        else 'Global'
+    end as mv_region,
+    mv_author_session_status,
+    geo_country,
+    device_category,
+    page_title,
+    page_location,
+    original_page_location,
+    page_referrer,
+    original_page_referrer,
+    pagepath_level_1,
+    pagepath_level_2,
+    content_type,
+    author,
+    scroll_position,
+    content_group,
+    content_topic,
+    entrances,
+    exits,
+    load_time
+from {{ ref('stg_ga4__event_page_view') }}
+{% if is_incremental() %}
+    {% if var('static_incremental_days', 1 ) %}
+        where event_date_dt in ({{ partitions_to_replace | join(',') }})
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
## Description & motivation

Taking advantage of some requirement changes in the ga4__authors model to migrate the authors and page_view marts from the project to the package so that shared code between FC and Inc comes from a single source while also standardizing model naming.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate exists tests