### PR TITLE
remove impossibly high engagement time values

### DIFF
--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -81,11 +81,15 @@ remove_query_params as (
         -- If there are query parameters to exclude, exclude them using regex
         {% if var('query_parameter_exclusions',none) is not none %}
         {{ga4.remove_query_parameters('page_location',var('query_parameter_exclusions'))}} as page_location,
-        {{ga4.remove_query_parameters('page_referrer',var('query_parameter_exclusions'))}} as page_referrer
+        {{ga4.remove_query_parameters('page_referrer',var('query_parameter_exclusions'))}} as page_referrer,
         {% else %}
         page_location,
-        page_referrer
+        page_referrer,
         {% endif %}
+        case
+            when engagement_time_msec >  1800000 then 0
+            else engagement_time_msec
+        end as engagement_time_msec
     from detect_gclid
 ),
 enrich_params as (


### PR DESCRIPTION
## Description & motivation

This filters engagement time values that exceed 30 minutes.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate exists tests